### PR TITLE
Add tests to validate baked-in FFDHE params

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,3 +363,21 @@ jobs:
       - name: run cargo-check-external-types for rustls/
         working-directory: rustls/
         run: cargo check-external-types
+
+  ci-only-tests:
+    name: Run ci-only-tests (in ci-tests/)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: cargo test (in ci-tests/)
+        working-directory: ci-tests/
+        run: cargo test --locked
+        env:
+          RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "asn1"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3ecbce89a22627b5e8e6e11d69715617138290289e385cde773b1fe50befdb"
+dependencies = [
+ "asn1_derive",
+]
+
+[[package]]
+name = "asn1_derive"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "861af988fac460ac69a09f41e6217a8fb9178797b76fcc9478444be6a59be19c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,6 +1744,15 @@ dependencies = [
  "rustls 0.23.0-alpha.0",
  "rustls-pemfile 2.0.0",
  "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-ci-tests"
+version = "0.0.1"
+dependencies = [
+ "asn1",
+ "base64",
+ "rustls 0.23.0-alpha.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 members = [
   # CI benchmarks
   "ci-bench",
+  # CI-only tests
+  "ci-tests",
   # Network-based tests
   "connect-tests",
   # tests and example code

--- a/ci-tests/Cargo.toml
+++ b/ci-tests/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rustls-ci-tests"
+version = "0.0.1"
+edition = "2021"
+license = "Apache-2.0 OR ISC OR MIT"
+description = "Rustls CI tests"
+publish = false
+
+[dependencies]
+rustls = { path = "../rustls" }
+base64 = "0.21"
+asn1 = "0.15"

--- a/ci-tests/src/lib.rs
+++ b/ci-tests/src/lib.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod validate_ffdhe_params;

--- a/ci-tests/src/validate_ffdhe_params.rs
+++ b/ci-tests/src/validate_ffdhe_params.rs
@@ -1,0 +1,128 @@
+use base64::prelude::*;
+use rustls::{ffdhe_groups::FfdheGroup, NamedGroup};
+
+/// If OpenSSL 3 is not avaialble, panics with a helpful message
+fn verify_openssl3_available() {
+    let openssl_output = std::process::Command::new("openssl")
+        .args(["version"])
+        .output();
+    match openssl_output {
+        Ok(output) => {
+            if !output.status.success() {
+                panic!(
+                    "OpenSSL exited with an error status: {}\n{}",
+                    output.status,
+                    std::str::from_utf8(&output.stderr).unwrap_or_default()
+                );
+            }
+            let version_str = std::str::from_utf8(&output.stdout).unwrap();
+            let parts = version_str
+                .split(' ')
+                .collect::<Vec<_>>();
+            assert_eq!(
+                parts.first().copied(),
+                Some("OpenSSL"),
+                "Unknown version response from OpenSSL: {version_str}"
+            );
+            let version = parts.get(1);
+            let major_version = version
+                .and_then(|v| v.split('.').next())
+                .unwrap_or_else(|| {
+                    panic!("Unexpected version response from OpenSSL: {version_str}")
+                });
+            assert!(
+                major_version
+                    .parse::<usize>()
+                    .is_ok_and(|v| v >= 3),
+                "OpenSSL 3+ is required for the tests here. The installed version is {version:?}"
+            );
+        }
+        Err(e) => {
+            panic!("OpenSSL 3+ needs to be installed and in PATH.\nThe error encountered: {e}")
+        }
+    }
+}
+
+/// Get FFDHE parameters `(p, g)`` for the given `ffdhe_group` from OpenSSL
+fn get_ffdhe_params_from_openssl(ffdhe_group: NamedGroup) -> (Vec<u8>, Vec<u8>) {
+    let group = match ffdhe_group {
+        NamedGroup::FFDHE2048 => "group:ffdhe2048",
+        NamedGroup::FFDHE3072 => "group:ffdhe3072",
+        NamedGroup::FFDHE4096 => "group:ffdhe4096",
+        NamedGroup::FFDHE6144 => "group:ffdhe6144",
+        NamedGroup::FFDHE8192 => "group:ffdhe8192",
+        _ => panic!("not an ffdhe group: {ffdhe_group:?}"),
+    };
+
+    let openssl_output = std::process::Command::new("openssl")
+        .args([
+            "genpkey",
+            "-genparam",
+            "-algorithm",
+            "DH",
+            "-text",
+            "-pkeyopt",
+            group,
+        ])
+        .output()
+        .unwrap();
+
+    parse_dh_params_pem(&openssl_output.stdout)
+}
+
+/// Parse PEM-encoded DH parameters, returning `(p, g)`
+fn parse_dh_params_pem(data: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    let output_str = std::str::from_utf8(data).unwrap();
+    let output_str_lines = output_str.lines().collect::<Vec<_>>();
+    assert_eq!(output_str_lines[0], "-----BEGIN DH PARAMETERS-----");
+
+    let last_line = output_str_lines
+        .iter()
+        .enumerate()
+        .find(|(_i, l)| **l == "-----END DH PARAMETERS-----")
+        .unwrap()
+        .0;
+
+    let stripped = &output_str_lines[1..last_line];
+
+    let base64_encoded = stripped
+        .iter()
+        .fold(String::new(), |acc, l| acc + l);
+
+    let base64_decoded = BASE64_STANDARD
+        .decode(base64_encoded)
+        .unwrap();
+
+    let res: asn1::ParseResult<_> = asn1::parse(&base64_decoded, |d| {
+        d.read_element::<asn1::Sequence>()?
+            .parse(|d| {
+                let p = d.read_element::<asn1::BigUint>()?;
+                let g = d.read_element::<asn1::BigUint>()?;
+                Ok((p, g))
+            })
+    });
+    let res = res.unwrap();
+    (res.0.as_bytes().to_vec(), res.1.as_bytes().to_vec())
+}
+
+fn test_ffdhe_params_correct(group: NamedGroup) {
+    let (p, g) = get_ffdhe_params_from_openssl(group);
+    let openssl_params = FfdheGroup::from_params_trimming_leading_zeros(&p, &g);
+    let rustls_params = FfdheGroup::from_named_group(group).unwrap();
+    assert_eq!(rustls_params.named_group(), Some(group));
+
+    assert_eq!(rustls_params, openssl_params);
+}
+
+#[test]
+fn ffdhe_params_correct() {
+    use NamedGroup::*;
+
+    verify_openssl3_available();
+
+    let groups = [FFDHE2048, FFDHE3072, FFDHE4096, FFDHE6144, FFDHE8192];
+    for group in groups {
+        println!("testing {group:?}");
+        test_ffdhe_params_correct(group);
+    }
+}

--- a/rustls/src/msgs/ffdhe_groups.rs
+++ b/rustls/src/msgs/ffdhe_groups.rs
@@ -1,6 +1,6 @@
 use crate::NamedGroup;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// Parameters of an FFDHE group, with Big-endian byte order
 pub struct FfdheGroup<'a> {
     pub p: &'a [u8],
@@ -32,6 +32,23 @@ impl<'a> FfdheGroup<'a> {
             FFDHE6144 => Some(NamedGroup::FFDHE6144),
             FFDHE8192 => Some(NamedGroup::FFDHE8192),
             _ => None,
+        }
+    }
+
+    /// Construct an `FfdheGroup` from the given `p` and `g`, trimming any potential leading zeros.
+    pub fn from_params_trimming_leading_zeros(p: &'a [u8], g: &'a [u8]) -> Self {
+        fn trim_leading_zeros(buf: &[u8]) -> &[u8] {
+            for start in 0..buf.len() {
+                if buf[start] != 0 {
+                    return &buf[start..];
+                }
+            }
+            &[]
+        }
+
+        FfdheGroup {
+            p: trim_leading_zeros(p),
+            g: trim_leading_zeros(g),
         }
     }
 }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1648,20 +1648,7 @@ impl ServerDhParams {
 
     #[cfg(feature = "tls12")]
     fn named_group(&self) -> Option<NamedGroup> {
-        fn trim_leading_zeros(buf: &[u8]) -> &[u8] {
-            for start in 0..buf.len() {
-                if buf[start] != 0 {
-                    return &buf[start..];
-                }
-            }
-            &[]
-        }
-
-        FfdheGroup {
-            p: trim_leading_zeros(&self.dh_p.0),
-            g: trim_leading_zeros(&self.dh_g.0),
-        }
-        .named_group()
+        FfdheGroup::from_params_trimming_leading_zeros(&self.dh_p.0, &self.dh_g.0).named_group()
     }
 }
 


### PR DESCRIPTION
The tests are added in the crate `ci-tests`. The reason is that they require OpenSSL 3, and we don't want to break `cargo test` on the `rustls` crate on dev machines.