### PR TITLE
Avoid picking cipher suite that has no kx groups in common with client

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -455,7 +455,6 @@ pub use crate::verify::DigitallySignedStruct;
 pub use crate::versions::{SupportedProtocolVersion, ALL_VERSIONS, DEFAULT_VERSIONS};
 pub use crate::webpki::RootCertStore;
 
-#[cfg(feature = "tls12")]
 pub use crate::msgs::ffdhe_groups;
 
 /// Items for use in a client.

--- a/rustls/src/msgs/ffdhe_groups.rs
+++ b/rustls/src/msgs/ffdhe_groups.rs
@@ -1,3 +1,6 @@
+//! This module contains parameters for FFDHE named groups as defined
+//! in [RFC 7919 Appendix A](https://datatracker.ietf.org/doc/html/rfc7919#appendix-A).
+
 use crate::NamedGroup;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -18,7 +18,6 @@ pub(crate) mod persist;
 #[cfg(test)]
 mod handshake_test;
 
-#[cfg(feature = "tls12")]
 pub mod ffdhe_groups;
 #[cfg(test)]
 mod message_test;

--- a/rustls/tests/common/ffdhe.rs
+++ b/rustls/tests/common/ffdhe.rs
@@ -25,7 +25,7 @@ static TLS12_DHE_RSA_WITH_AES_128_GCM_SHA256: Tls12CipherSuite =
         _ => unreachable!(),
     };
 
-/// The (test-only) TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+/// The (test-only) TLS1.2 ciphersuite TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
 pub static TLS_DHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
     SupportedCipherSuite::Tls12(&TLS12_DHE_RSA_WITH_AES_128_GCM_SHA256);
 
@@ -89,7 +89,9 @@ impl ActiveKeyExchange for ActiveFfdheKx {
 }
 
 pub const FFDHE2048_KX_GROUP: FfdheKxGroup = FfdheKxGroup(NamedGroup::FFDHE2048);
-static FFDHE_KX_GROUPS: &[&dyn rustls::crypto::SupportedKxGroup] = &[&FFDHE2048_KX_GROUP];
+pub const FFDHE3072_KX_GROUP: FfdheKxGroup = FfdheKxGroup(NamedGroup::FFDHE3072);
+static FFDHE_KX_GROUPS: &[&dyn rustls::crypto::SupportedKxGroup] =
+    &[&FFDHE2048_KX_GROUP, &FFDHE3072_KX_GROUP];
 
 pub fn ffdhe_provider() -> CryptoProvider {
     CryptoProvider {


### PR DESCRIPTION
With more than one key exchange algorithm supported by rustls, we may get into a situation where the server and client both support a cipher suite, but they have no common kx groups for that cipher suite. 

Currently if this happens, rustls server may choose that cipher suite and later terminate the handshake with `NoKxGroupsInCommon` alert. 

With this PR, the server avoids those cipher suites and looks for a cipher suite where both client and server support a kx group for that cipher suite.

(Unrelated to this, this PR also removes the `tls12` feature gate from `ffdhe_groups`, to let tls13-only custom `CryptoProvider`s use the parameters provided in `ffdhe_groups` if they wish to support FFDHE key exchange) 