### PR TITLE
Revert "server: allow sending empty root hints list"

### DIFF
--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -713,13 +713,15 @@ mod client_hello {
         cr.extensions
             .push(CertReqExtension::SignatureAlgorithms(schemes.to_vec()));
 
-        cr.extensions
-            .push(CertReqExtension::AuthorityNames(
-                config
-                    .verifier
-                    .root_hint_subjects()
-                    .to_vec(),
-            ));
+        let names = config
+            .verifier
+            .root_hint_subjects()
+            .to_vec();
+
+        if !names.is_empty() {
+            cr.extensions
+                .push(CertReqExtension::AuthorityNames(names));
+        }
 
         let m = Message {
             version: ProtocolVersion::TLSv1_3,

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -160,8 +160,8 @@ pub trait ClientCertVerifier: Debug + Send + Sync {
     /// These hint values help the client pick a client certificate it believes the server will
     /// accept. The hints must be DER-encoded X.500 distinguished names, per [RFC 5280 A.1]. They
     /// are sent in the [`certificate_authorities`] extension of a [`CertificateRequest`] message
-    /// when [ClientCertVerifier::offer_client_auth] is true. When an empty list is sent the client
-    /// should always provide a client certificate if it has one.
+    /// when [ClientCertVerifier::offer_client_auth] is true. If the return value is empty, no
+    /// CertificateRequest message will be sent.
     ///
     /// Generally this list should contain the [`DistinguishedName`] of each root trust
     /// anchor in the root cert store that the server is configured to use for authenticating


### PR DESCRIPTION
This reverts commit 7dfbdb8efd177a9586635f2ff12d43f07ab90689.