### PR TITLE
Test FFDHE impl against OpenSSL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,8 +376,11 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: openssl version
+        run: openssl version
+
       - name: cargo test (in ci-tests/)
         working-directory: ci-tests/
-        run: cargo test --locked
+        run: cargo test --locked -- --include-ignored
         env:
           RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,6 +1615,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1774,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "platforms"
@@ -2093,7 +2152,12 @@ version = "0.0.1"
 dependencies = [
  "asn1",
  "base64",
+ "num-bigint",
+ "once_cell",
+ "openssl",
  "rustls 0.23.0-alpha.0",
+ "rustls-pemfile 2.0.0",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2614,6 +2678,12 @@ name = "value-bag"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/ci-tests/Cargo.toml
+++ b/ci-tests/Cargo.toml
@@ -1,12 +1,17 @@
 [package]
-name = "rustls-ci-tests"
-version = "0.0.1"
+description = "Rustls CI tests"
 edition = "2021"
 license = "Apache-2.0 OR ISC OR MIT"
-description = "Rustls CI tests"
+name = "rustls-ci-tests"
 publish = false
+version = "0.0.1"
 
 [dependencies]
-rustls = { path = "../rustls" }
-base64 = "0.21"
 asn1 = "0.15"
+base64 = "0.21"
+num-bigint = "0.4.4"
+once_cell = "1.19"
+rustls = {path = "../rustls"}
+rustls-pemfile = "2"
+rustls-pki-types = "1.0"
+openssl = "0.10"

--- a/ci-tests/src/ffdhe.rs
+++ b/ci-tests/src/ffdhe.rs
@@ -1,0 +1,90 @@
+use num_bigint::BigUint;
+use rustls::{
+    crypto::{
+        ActiveKeyExchange, CipherSuiteCommon, KeyExchangeAlgorithm, SharedSecret, SupportedKxGroup,
+    },
+    ffdhe_groups::FfdheGroup,
+    CipherSuite, NamedGroup, SupportedCipherSuite, Tls12CipherSuite,
+};
+
+static TLS12_DHE_RSA_WITH_AES_128_GCM_SHA256: Tls12CipherSuite =
+    match &rustls::crypto::ring::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+        SupportedCipherSuite::Tls12(provider) => Tls12CipherSuite {
+            common: CipherSuiteCommon {
+                suite: CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+                ..provider.common
+            },
+            kx: KeyExchangeAlgorithm::DHE,
+            ..**provider
+        },
+        _ => unreachable!(),
+    };
+
+/// The (test-only) TLS1.2 ciphersuite TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+pub static TLS_DHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
+    SupportedCipherSuite::Tls12(&TLS12_DHE_RSA_WITH_AES_128_GCM_SHA256);
+
+#[derive(Debug)]
+pub struct FfdheKxGroup(pub NamedGroup);
+
+impl SupportedKxGroup for FfdheKxGroup {
+    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, rustls::Error> {
+        let mut x = vec![0; 64];
+        rustls::crypto::ring::default_provider()
+            .secure_random
+            .fill(&mut x)?;
+        let x = BigUint::from_bytes_be(&x);
+
+        let group = FfdheGroup::from_named_group(self.0).unwrap();
+        let p = BigUint::from_bytes_be(group.p);
+        let g = BigUint::from_bytes_be(group.g);
+
+        let x_pub = g.modpow(&x, &p);
+        let x_pub = to_bytes_be_with_len(x_pub, group.p.len());
+
+        Ok(Box::new(ActiveFfdheKx {
+            x_pub,
+            x,
+            p,
+            group,
+            named_group: self.0,
+        }))
+    }
+
+    fn name(&self) -> NamedGroup {
+        self.0
+    }
+}
+
+struct ActiveFfdheKx {
+    x_pub: Vec<u8>,
+    x: BigUint,
+    p: BigUint,
+    group: FfdheGroup<'static>,
+    named_group: NamedGroup,
+}
+
+impl ActiveKeyExchange for ActiveFfdheKx {
+    fn complete(self: Box<Self>, peer_pub_key: &[u8]) -> Result<SharedSecret, rustls::Error> {
+        let peer_pub = BigUint::from_bytes_be(peer_pub_key);
+        let secret = peer_pub.modpow(&self.x, &self.p);
+        let secret = to_bytes_be_with_len(secret, self.group.p.len());
+
+        Ok(SharedSecret::from(&secret[..]))
+    }
+
+    fn pub_key(&self) -> &[u8] {
+        &self.x_pub
+    }
+
+    fn group(&self) -> NamedGroup {
+        self.named_group
+    }
+}
+
+fn to_bytes_be_with_len(n: BigUint, len_bytes: usize) -> Vec<u8> {
+    let mut bytes = n.to_bytes_le();
+    bytes.resize(len_bytes, 0);
+    bytes.reverse();
+    bytes
+}

--- a/ci-tests/src/lib.rs
+++ b/ci-tests/src/lib.rs
@@ -1,2 +1,6 @@
-#[cfg(test)]
+#![cfg(test)]
+
+mod ffdhe;
+mod test_ffdhe_kx_against_openssl;
+mod utils;
 mod validate_ffdhe_params;

--- a/ci-tests/src/test_ffdhe_kx_against_openssl.rs
+++ b/ci-tests/src/test_ffdhe_kx_against_openssl.rs
@@ -1,0 +1,239 @@
+use std::{
+    fs::{self, File},
+    io::{BufReader, Read, Write},
+    net::{TcpListener, TcpStream},
+    str,
+    sync::Arc,
+    thread,
+};
+
+use rustls::{
+    crypto::{ring::default_provider, CryptoProvider},
+    version::{TLS12, TLS13},
+    ClientConfig, RootCertStore, ServerConfig, SupportedProtocolVersion,
+};
+use rustls_pemfile::Item;
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+
+use crate::{
+    ffdhe::{self, FfdheKxGroup},
+    utils::verify_openssl3_available,
+};
+
+use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
+
+const CERT_CHAIN_FILE: &str = "../test-ca/rsa/end.fullchain";
+const PRIV_KEY_FILE: &str = "../test-ca/rsa/end.key";
+const CA_FILE: &str = "../test-ca/rsa/ca.der";
+const CA_PEM_FILE: &str = "../test-ca/rsa/ca.cert";
+
+fn root_ca() -> RootCertStore {
+    let mut res = RootCertStore::empty();
+    res.add_parsable_certificates([CertificateDer::from(fs::read(CA_FILE).unwrap())]);
+    res
+}
+
+fn load_certs() -> Vec<CertificateDer<'static>> {
+    let mut reader = BufReader::new(File::open(CERT_CHAIN_FILE).unwrap());
+    rustls_pemfile::certs(&mut reader)
+        .map(|c| c.unwrap())
+        .collect()
+}
+
+fn load_private_key() -> PrivateKeyDer<'static> {
+    let mut reader = BufReader::new(File::open(PRIV_KEY_FILE).unwrap());
+
+    match rustls_pemfile::read_one(&mut reader)
+        .unwrap()
+        .unwrap()
+    {
+        Item::Pkcs1Key(key) => key.into(),
+        Item::Pkcs8Key(key) => key.into(),
+        Item::Sec1Key(key) => key.into(),
+        _ => panic!("no key in key file {PRIV_KEY_FILE}"),
+    }
+}
+
+fn ffdhe_provider() -> CryptoProvider {
+    CryptoProvider {
+        cipher_suites: vec![
+            ffdhe::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+            rustls::crypto::ring::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        ],
+        kx_groups: vec![&FfdheKxGroup(rustls::NamedGroup::FFDHE2048)],
+        ..default_provider()
+    }
+}
+
+fn server_config_with_ffdhe_kx(protocol: &'static SupportedProtocolVersion) -> ServerConfig {
+    ServerConfig::builder_with_provider(ffdhe_provider().into())
+        .with_protocol_versions(&[protocol])
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(load_certs(), load_private_key())
+        .unwrap()
+}
+
+#[test]
+fn rustls_server_with_ffdhe_kx_tls13() {
+    test_rustls_server_with_ffdhe_kx(&TLS13, 1)
+}
+
+#[test]
+fn rustls_server_with_ffdhe_kx_tls12() {
+    test_rustls_server_with_ffdhe_kx(&TLS12, 1)
+}
+
+fn test_rustls_server_with_ffdhe_kx(
+    protocol_version: &'static SupportedProtocolVersion,
+    iters: usize,
+) {
+    verify_openssl3_available();
+
+    let message = "Hello from rustls!\n";
+
+    let listener = std::net::TcpListener::bind(("localhost", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let server_thread = std::thread::spawn(move || {
+        let config = Arc::new(server_config_with_ffdhe_kx(protocol_version));
+        for _ in 0..iters {
+            let mut server = rustls::ServerConnection::new(config.clone()).unwrap();
+            let (mut tcp_stream, _addr) = listener.accept().unwrap();
+            server
+                .writer()
+                .write_all(message.as_bytes())
+                .unwrap();
+            server
+                .complete_io(&mut tcp_stream)
+                .unwrap();
+            tcp_stream.flush().unwrap();
+        }
+    });
+
+    let mut connector = openssl::ssl::SslConnector::builder(SslMethod::tls()).unwrap();
+    connector
+        .set_ca_file(CA_PEM_FILE)
+        .unwrap();
+    connector
+        .set_groups_list("ffdhe2048")
+        .unwrap();
+
+    let connector = connector.build();
+
+    for _iter in 0..iters {
+        let stream = TcpStream::connect(("localhost", port)).unwrap();
+        let mut stream = connector
+            .connect("testserver.com", stream)
+            .unwrap();
+
+        let mut buf = String::new();
+        stream.read_to_string(&mut buf).unwrap();
+        assert_eq!(buf, message);
+    }
+
+    server_thread.join().unwrap();
+}
+
+fn client_config_with_ffdhe_kx() -> ClientConfig {
+    ClientConfig::builder_with_provider(ffdhe_provider().into())
+        // OpenSSL 3 does not support RFC 7919 with TLS 1.2: https://github.com/openssl/openssl/issues/10971
+        .with_protocol_versions(&[&TLS13])
+        .unwrap()
+        .with_root_certificates(root_ca())
+        .with_no_client_auth()
+}
+
+#[test]
+fn rustls_client_with_ffdhe_kx() {
+    test_rustls_client_with_ffdhe_kx(1);
+}
+
+fn test_rustls_client_with_ffdhe_kx(iters: usize) {
+    verify_openssl3_available();
+
+    let message = "Hello from rustls!\n";
+
+    println!("crate openssl version: {}", openssl::version::version());
+
+    let mut acceptor = SslAcceptor::mozilla_modern_v5(SslMethod::tls()).unwrap();
+    acceptor
+        .set_groups_list("ffdhe2048")
+        .unwrap();
+    acceptor
+        .set_private_key_file(PRIV_KEY_FILE, SslFiletype::PEM)
+        .unwrap();
+    acceptor
+        .set_certificate_chain_file(CERT_CHAIN_FILE)
+        .unwrap();
+    acceptor.check_private_key().unwrap();
+    let acceptor = Arc::new(acceptor.build());
+
+    let listener = TcpListener::bind(("localhost", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let server_thread = std::thread::spawn(move || {
+        for stream in listener.incoming().take(iters) {
+            match stream {
+                Ok(stream) => {
+                    let acceptor = acceptor.clone();
+                    thread::spawn(move || {
+                        let mut stream = acceptor.accept(stream).unwrap();
+                        let mut buf = String::new();
+                        stream.read_to_string(&mut buf).unwrap();
+                        assert_eq!(buf, message);
+                    });
+                }
+                Err(e) => {
+                    panic!("openssl connection failed: {e}");
+                }
+            }
+        }
+    });
+
+    // client:
+    for _ in 0..iters {
+        let mut tcp_stream = std::net::TcpStream::connect(("localhost", port)).unwrap();
+        let mut client = rustls::client::ClientConnection::new(
+            client_config_with_ffdhe_kx().into(),
+            "localhost".try_into().unwrap(),
+        )
+        .unwrap();
+        client
+            .writer()
+            .write_all(message.as_bytes())
+            .unwrap();
+        client
+            .complete_io(&mut tcp_stream)
+            .unwrap();
+        client.send_close_notify();
+        client
+            .write_tls(&mut tcp_stream)
+            .unwrap();
+        tcp_stream.flush().unwrap();
+    }
+
+    server_thread.join().unwrap();
+}
+
+// TLS 1.2 requires stripping leading zeros of the shared secret,
+// While TLS 1.3 requires the shared secret to be padded with zeros.
+// The chance of getting a shared secret with the first byte being zero is 1 in 256,
+// so we repeat the tests to have a high chance of getting a kx with this property.
+#[test]
+#[ignore]
+fn rustls_client_with_ffdhe_kx_repeated() {
+    test_rustls_client_with_ffdhe_kx(512);
+}
+
+#[test]
+#[ignore]
+fn rustls_server_with_ffdhe_tls13_repeated() {
+    test_rustls_server_with_ffdhe_kx(&TLS13, 512)
+}
+
+#[test]
+#[ignore]
+fn rustls_server_with_ffdhe_tls12_repeated() {
+    test_rustls_server_with_ffdhe_kx(&TLS12, 512);
+}

--- a/ci-tests/src/utils.rs
+++ b/ci-tests/src/utils.rs
@@ -1,0 +1,48 @@
+use once_cell::sync::Lazy;
+
+/// If OpenSSL 3 is not avaialble, panics with a helpful message
+fn verify_openssl3_available_internal() {
+    let openssl_output = std::process::Command::new("openssl")
+        .args(["version"])
+        .output();
+    match openssl_output {
+        Ok(output) => {
+            if !output.status.success() {
+                panic!(
+                    "OpenSSL exited with an error status: {}\n{}",
+                    output.status,
+                    std::str::from_utf8(&output.stderr).unwrap_or_default()
+                );
+            }
+            let version_str = std::str::from_utf8(&output.stdout).unwrap();
+            let parts = version_str
+                .split(' ')
+                .collect::<Vec<_>>();
+            assert_eq!(
+                parts.first().copied(),
+                Some("OpenSSL"),
+                "Unknown version response from OpenSSL: {version_str}"
+            );
+            let version = parts.get(1);
+            let major_version = version
+                .and_then(|v| v.split('.').next())
+                .unwrap_or_else(|| {
+                    panic!("Unexpected version response from OpenSSL: {version_str}")
+                });
+            assert!(
+                major_version
+                    .parse::<usize>()
+                    .is_ok_and(|v| v >= 3),
+                "OpenSSL 3+ is required for the tests here. The installed version is {version:?}"
+            );
+        }
+        Err(e) => {
+            panic!("OpenSSL 3+ needs to be installed and in PATH.\nThe error encountered: {e}")
+        }
+    }
+}
+
+pub fn verify_openssl3_available() {
+    static VERIFIED: Lazy<()> = Lazy::new(verify_openssl3_available_internal);
+    *VERIFIED
+}

--- a/ci-tests/src/validate_ffdhe_params.rs
+++ b/ci-tests/src/validate_ffdhe_params.rs
@@ -1,47 +1,7 @@
 use base64::prelude::*;
 use rustls::{ffdhe_groups::FfdheGroup, NamedGroup};
 
-/// If OpenSSL 3 is not avaialble, panics with a helpful message
-fn verify_openssl3_available() {
-    let openssl_output = std::process::Command::new("openssl")
-        .args(["version"])
-        .output();
-    match openssl_output {
-        Ok(output) => {
-            if !output.status.success() {
-                panic!(
-                    "OpenSSL exited with an error status: {}\n{}",
-                    output.status,
-                    std::str::from_utf8(&output.stderr).unwrap_or_default()
-                );
-            }
-            let version_str = std::str::from_utf8(&output.stdout).unwrap();
-            let parts = version_str
-                .split(' ')
-                .collect::<Vec<_>>();
-            assert_eq!(
-                parts.first().copied(),
-                Some("OpenSSL"),
-                "Unknown version response from OpenSSL: {version_str}"
-            );
-            let version = parts.get(1);
-            let major_version = version
-                .and_then(|v| v.split('.').next())
-                .unwrap_or_else(|| {
-                    panic!("Unexpected version response from OpenSSL: {version_str}")
-                });
-            assert!(
-                major_version
-                    .parse::<usize>()
-                    .is_ok_and(|v| v >= 3),
-                "OpenSSL 3+ is required for the tests here. The installed version is {version:?}"
-            );
-        }
-        Err(e) => {
-            panic!("OpenSSL 3+ needs to be installed and in PATH.\nThe error encountered: {e}")
-        }
-    }
-}
+use crate::utils::verify_openssl3_available;
 
 /// Get FFDHE parameters `(p, g)` for the given `ffdhe_group` from OpenSSL
 fn get_ffdhe_params_from_openssl(ffdhe_group: NamedGroup) -> (Vec<u8>, Vec<u8>) {

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -10,6 +10,7 @@ use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
 use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls12::Tls12CipherSuite;
+use crate::version::TLS12;
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -426,7 +427,7 @@ impl Prf for Tls12Prf {
     ) -> Result<(), Error> {
         self.for_secret(
             output,
-            kx.complete(peer_pub_key)?
+            kx.complete_for_tls_version(peer_pub_key, &TLS12)?
                 .secret_bytes(),
             label,
             seed,

--- a/rustls/src/crypto/tls12.rs
+++ b/rustls/src/crypto/tls12.rs
@@ -1,6 +1,7 @@
 use super::hmac;
 use super::ActiveKeyExchange;
 use crate::error::Error;
+use crate::version::TLS12;
 
 use alloc::boxed::Box;
 
@@ -20,7 +21,7 @@ impl<'a> Prf for PrfUsingHmac<'a> {
             output,
             self.0
                 .with_key(
-                    kx.complete(peer_pub_key)?
+                    kx.complete_for_tls_version(peer_pub_key, &TLS12)?
                         .secret_bytes(),
                 )
                 .as_ref(),

--- a/rustls/src/crypto/tls13.rs
+++ b/rustls/src/crypto/tls13.rs
@@ -1,6 +1,7 @@
 use super::hmac;
 use super::ActiveKeyExchange;
 use crate::error::Error;
+use crate::version::TLS13;
 
 use alloc::boxed::Box;
 use zeroize::Zeroize;
@@ -160,7 +161,7 @@ pub trait Hkdf: Send + Sync {
     ) -> Result<Box<dyn HkdfExpander>, Error> {
         Ok(self.extract_from_secret(
             salt,
-            kx.complete(peer_pub_key)?
+            kx.complete_for_tls_version(peer_pub_key, &TLS13)?
                 .secret_bytes(),
         ))
     }


### PR DESCRIPTION
When adding the tests, I discovered that there is an issue with handling leading zeros in the shared secret derived by FFDHE. The cause is that TLS 1.3 and 1.2 have different requirements:

TLS 1.3 requires that the derived secret be left-padded with zeros:
https://www.rfc-editor.org/rfc/rfc8446#section-7.4.1

TLS 1.2 requires that leading zero bytes be stripped:
https://www.rfc-editor.org/rfc/rfc5246#section-8.1.2

This PR includes a commit for fixing that by adding a `complete_for_tls_version()` function to `ActiveKeExchange`, and modifying consumers of `ActiveKeyExchange` to call this function instead of `complete()`.