### PR TITLE
Add config for force using `extended_master_secret` extension in TLS 1.2

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -159,6 +159,8 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             key_log: Arc::new(NoKeyLog {}),
             enable_secret_extraction: false,
             enable_early_data: false,
+            #[cfg(feature = "tls12")]
+            force_using_ems: false,
         }
     }
 }

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -160,7 +160,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             enable_secret_extraction: false,
             enable_early_data: false,
             #[cfg(feature = "tls12")]
-            force_using_ems: false,
+            require_ems: false,
         }
     }
 }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -193,6 +193,10 @@ pub struct ClientConfig {
     /// The default is false.
     pub enable_early_data: bool,
 
+    /// Whether to ensure "extended_master_secret" extension is used.
+    #[cfg(feature = "tls12")]
+    pub force_using_ems: bool,
+
     /// Source of randomness and other crypto.
     pub(super) provider: Arc<CryptoProvider>,
 
@@ -308,6 +312,7 @@ impl Clone for ClientConfig {
             key_log: Arc::clone(&self.key_log),
             enable_secret_extraction: self.enable_secret_extraction,
             enable_early_data: self.enable_early_data,
+            force_using_ems: self.force_using_ems,
         }
     }
 }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -316,6 +316,7 @@ impl Clone for ClientConfig {
             key_log: Arc::clone(&self.key_log),
             enable_secret_extraction: self.enable_secret_extraction,
             enable_early_data: self.enable_early_data,
+            #[cfg(feature = "tls12")]
             require_ems: self.require_ems,
         }
     }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -193,9 +193,13 @@ pub struct ClientConfig {
     /// The default is false.
     pub enable_early_data: bool,
 
-    /// Whether to ensure "extended_master_secret" extension is used.
+    /// If set to `true`, requires the server to support the extended
+    /// master secret extraction method defined in [RFC 7627].
+    /// The default is `false`.
+    ///
+    /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
     #[cfg(feature = "tls12")]
-    pub force_using_ems: bool,
+    pub require_ems: bool,
 
     /// Source of randomness and other crypto.
     pub(super) provider: Arc<CryptoProvider>,
@@ -312,7 +316,7 @@ impl Clone for ClientConfig {
             key_log: Arc::clone(&self.key_log),
             enable_secret_extraction: self.enable_secret_extraction,
             enable_early_data: self.enable_early_data,
-            force_using_ems: self.force_using_ems,
+            require_ems: self.require_ems,
         }
     }
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -81,7 +81,7 @@ mod server_hello {
 
             // Doing EMS?
             self.using_ems = server_hello.ems_support_acked();
-            if self.config.force_using_ems && !self.using_ems {
+            if self.config.require_ems && !self.using_ems {
                 return Err({
                     cx.common.send_fatal_alert(
                         AlertDescription::HandshakeFailure,

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -3,7 +3,7 @@ use crate::common_state::{CommonState, Side, State};
 use crate::conn::ConnectionRandoms;
 use crate::enums::ProtocolVersion;
 use crate::enums::{AlertDescription, ContentType, HandshakeType};
-use crate::error::{Error, InvalidMessage, PeerMisbehaved};
+use crate::error::{Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
@@ -81,6 +81,14 @@ mod server_hello {
 
             // Doing EMS?
             self.using_ems = server_hello.ems_support_acked();
+            if self.config.force_using_ems && !self.using_ems {
+                return Err({
+                    cx.common.send_fatal_alert(
+                        AlertDescription::HandshakeFailure,
+                        PeerIncompatible::ExtendedMasterSecretExtensionRequired,
+                    )
+                });
+            }
 
             // Might the server send a ticket?
             let must_issue_new_ticket = if server_hello

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -274,6 +274,7 @@ pub enum PeerIncompatible {
     Tls12NotOfferedOrEnabled,
     Tls13RequiredForQuic,
     UncompressedEcPointsRequired,
+    ExtendedMasterSecretExtensionRequired,
 }
 
 impl From<PeerIncompatible> for Error {

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -125,7 +125,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             send_half_rtt_data: false,
             send_tls13_tickets: 4,
             #[cfg(feature = "tls12")]
-            force_using_ems: false,
+            require_ems: false,
         }
     }
 }

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -124,6 +124,8 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             max_early_data_size: 0,
             send_half_rtt_data: false,
             send_tls13_tickets: 4,
+            #[cfg(feature = "tls12")]
+            force_using_ems: false,
         }
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -403,24 +403,28 @@ impl ExpectClientHello {
             }
             .handle_client_hello(cx, certkey, m, client_hello, sig_schemes),
             #[cfg(feature = "tls12")]
-            SupportedCipherSuite::Tls12(suite) => tls12::CompleteClientHelloHandling {
-                config: self.config,
-                transcript,
-                session_id: self.session_id,
-                suite,
-                using_ems: self.using_ems,
-                randoms,
-                send_ticket: self.send_tickets > 0,
-                extra_exts: self.extra_exts,
+            SupportedCipherSuite::Tls12(suite) => {
+                let force_using_ems = self.config.force_using_ems;
+                tls12::CompleteClientHelloHandling {
+                    config: self.config,
+                    transcript,
+                    session_id: self.session_id,
+                    suite,
+                    using_ems: self.using_ems,
+                    force_using_ems,
+                    randoms,
+                    send_ticket: self.send_tickets > 0,
+                    extra_exts: self.extra_exts,
+                }
+                .handle_client_hello(
+                    cx,
+                    certkey,
+                    m,
+                    client_hello,
+                    sig_schemes,
+                    tls13_enabled,
+                )
             }
-            .handle_client_hello(
-                cx,
-                certkey,
-                m,
-                client_hello,
-                sig_schemes,
-                tls13_enabled,
-            ),
         }
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -404,7 +404,7 @@ impl ExpectClientHello {
             .handle_client_hello(cx, certkey, m, client_hello, sig_schemes),
             #[cfg(feature = "tls12")]
             SupportedCipherSuite::Tls12(suite) => {
-                let force_using_ems = self.config.force_using_ems;
+                let force_using_ems = self.config.require_ems;
                 tls12::CompleteClientHelloHandling {
                     config: self.config,
                     transcript,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -316,9 +316,13 @@ pub struct ServerConfig {
     /// do any resumption.
     pub send_tls13_tickets: usize,
 
-    /// Whether require client to always send "extended_master_secret" extension
+    /// If set to `true`, requires the client to support the extended
+    /// master secret extraction method defined in [RFC 7627].
+    /// The default is `false`.
+    ///
+    /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
     #[cfg(feature = "tls12")]
-    pub force_using_ems: bool,
+    pub require_ems: bool,
 }
 
 // Avoid a `Clone` bound on `C`.
@@ -340,7 +344,7 @@ impl Clone for ServerConfig {
             send_half_rtt_data: self.send_half_rtt_data,
             send_tls13_tickets: self.send_tls13_tickets,
             #[cfg(feature = "tls12")]
-            force_using_ems: self.force_using_ems,
+            require_ems: self.require_ems,
         }
     }
 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -315,6 +315,10 @@ pub struct ServerConfig {
     /// If this is 0, no tickets are sent and clients will not be able to
     /// do any resumption.
     pub send_tls13_tickets: usize,
+
+    /// Whether require client to always send "extended_master_secret" extension
+    #[cfg(feature = "tls12")]
+    pub force_using_ems: bool,
 }
 
 // Avoid a `Clone` bound on `C`.
@@ -335,6 +339,8 @@ impl Clone for ServerConfig {
             max_early_data_size: self.max_early_data_size,
             send_half_rtt_data: self.send_half_rtt_data,
             send_tls13_tickets: self.send_tls13_tickets,
+            #[cfg(feature = "tls12")]
+            force_using_ems: self.force_using_ems,
         }
     }
 }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -61,6 +61,7 @@ mod client_hello {
         pub(in crate::server) session_id: SessionId,
         pub(in crate::server) suite: &'static Tls12CipherSuite,
         pub(in crate::server) using_ems: bool,
+        pub(in crate::server) force_using_ems: bool,
         pub(in crate::server) randoms: ConnectionRandoms,
         pub(in crate::server) send_ticket: bool,
         pub(in crate::server) extra_exts: Vec<ServerExtension>,
@@ -81,6 +82,11 @@ mod client_hello {
 
             if client_hello.ems_support_offered() {
                 self.using_ems = true;
+            } else if self.force_using_ems {
+                return Err(cx.common.send_fatal_alert(
+                    AlertDescription::HandshakeFailure,
+                    PeerIncompatible::ExtendedMasterSecretExtensionRequired,
+                ));
             }
 
             let groups_ext = client_hello

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5057,6 +5057,69 @@ fn test_client_rejects_illegal_tls13_ccs() {
     );
 }
 
+#[cfg(feature = "tls12")]
+fn remove_ems_request(msg: &mut Message) -> Altered {
+    if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
+        if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
+            ch.extensions.retain(|ext| {
+                if let ClientExtension::ExtendedMasterSecretRequest = ext {
+                    false
+                } else {
+                    true
+                }
+            })
+        }
+
+        *encoded = Payload::new(parsed.get_encoding());
+    }
+
+    Altered::InPlace
+}
+
+#[cfg(feature = "tls12")]
+#[test]
+fn test_client_rejects_no_extended_master_secret_extension_when_force_using_ems() {
+    let key_type = KeyType::Rsa;
+    let mut client_config = make_client_config(key_type);
+    client_config.force_using_ems = true;
+    let server_config = finish_server_config(
+        key_type,
+        server_config_builder_with_versions(&[&rustls::version::TLS12]),
+    );
+    let (client, server) = make_pair_for_configs(client_config, server_config);
+    let (mut client, mut server) = (client.into(), server.into());
+    transfer_altered(&mut client, remove_ems_request, &mut server);
+    server.process_new_packets().unwrap();
+    transfer_altered(&mut server, |_| Altered::InPlace, &mut client);
+    assert_eq!(
+        client.process_new_packets(),
+        Err(Error::PeerIncompatible(
+            PeerIncompatible::ExtendedMasterSecretExtensionRequired
+        ))
+    );
+}
+
+#[cfg(feature = "tls12")]
+#[test]
+fn test_server_rejects_no_extended_master_secret_extension_when_force_using_ems() {
+    let key_type = KeyType::Rsa;
+    let client_config = make_client_config(key_type);
+    let mut server_config = finish_server_config(
+        key_type,
+        server_config_builder_with_versions(&[&rustls::version::TLS12]),
+    );
+    server_config.force_using_ems = true;
+    let (client, server) = make_pair_for_configs(client_config, server_config);
+    let (mut client, mut server) = (client.into(), server.into());
+    transfer_altered(&mut client, remove_ems_request, &mut server);
+    assert_eq!(
+        server.process_new_packets(),
+        Err(Error::PeerIncompatible(
+            PeerIncompatible::ExtendedMasterSecretExtensionRequired
+        ))
+    );
+}
+
 /// https://github.com/rustls/rustls/issues/797
 #[cfg(feature = "tls12")]
 #[test]

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5061,7 +5061,8 @@ fn test_client_rejects_illegal_tls13_ccs() {
 fn remove_ems_request(msg: &mut Message) -> Altered {
     if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
         if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
-            ch.extensions.retain(|ext| !matches!(ext, ClientExtension::ExtendedMasterSecretRequest) )
+            ch.extensions
+                .retain(|ext| !matches!(ext, ClientExtension::ExtendedMasterSecretRequest))
         }
 
         *encoded = Payload::new(parsed.get_encoding());


### PR DESCRIPTION
This PR:
- Added config field in client config to force using `extended_master_secret` extension in TLS 1.2.
- Added config field in server config to force using `extended_master_secret` extension in TLS 1.2.
- Added test cases to ensure client/server will terminate handshake when force using force using `extended_master_secret` extension but peer does not send it.

Reason for this change:
- New FIPS application that use `rustls` needs a way to ensure `extended_master_secret` extension is always used in TLS 1.2 to fullfill the requirements mentioned in Section **"D.Q Transition of the TLS 1.2 KDF to Support the Extended Master Secret"** from [FIPS 140-3 IG.pdf](https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf):

  > A new validation, or any revalidation that extends the module’s sunset date, submitted more than one year 
  > after the publication date of this IG shall use the extended master secret in the TLS 1.2 KDF. The 
  > revalidations not extending the module’s sunset date are not subject to this requirement