### PR TITLE
[back-port] [ffdhe] Add config for force using extended_master_secret extension in TLS 1.2

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -159,6 +159,8 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             key_log: Arc::new(NoKeyLog {}),
             enable_secret_extraction: false,
             enable_early_data: false,
+            #[cfg(feature = "tls12")]
+            require_ems: false,
         }
     }
 }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -200,6 +200,14 @@ pub struct ClientConfig {
     ///
     /// The default is false.
     pub enable_early_data: bool,
+
+    /// If set to `true`, requires the server to support the extended
+    /// master secret extraction method defined in [RFC 7627].
+    /// The default is `false`.
+    ///
+    /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
+    #[cfg(feature = "tls12")]
+    pub require_ems: bool,
 }
 
 /// What mechanisms to support for resuming a TLS 1.2 session.
@@ -232,6 +240,8 @@ impl Clone for ClientConfig {
             key_log: Arc::clone(&self.key_log),
             enable_secret_extraction: self.enable_secret_extraction,
             enable_early_data: self.enable_early_data,
+            #[cfg(feature = "tls12")]
+            require_ems: self.require_ems,
         }
     }
 }

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -274,6 +274,7 @@ pub enum PeerIncompatible {
     Tls12NotOfferedOrEnabled,
     Tls13RequiredForQuic,
     UncompressedEcPointsRequired,
+    ExtendedMasterSecretExtensionRequired,
 }
 
 impl From<PeerIncompatible> for Error {

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -124,6 +124,8 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             max_early_data_size: 0,
             send_half_rtt_data: false,
             send_tls13_tickets: 4,
+            #[cfg(feature = "tls12")]
+            require_ems: false,
         }
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -429,24 +429,28 @@ impl ExpectClientHello {
             }
             .handle_client_hello(cx, certkey, m, client_hello, sig_schemes),
             #[cfg(feature = "tls12")]
-            SupportedCipherSuite::Tls12(suite) => tls12::CompleteClientHelloHandling {
-                config: self.config,
-                transcript,
-                session_id: self.session_id,
-                suite,
-                using_ems: self.using_ems,
-                randoms,
-                send_ticket: self.send_tickets > 0,
-                extra_exts: self.extra_exts,
+            SupportedCipherSuite::Tls12(suite) => {
+                let force_using_ems = self.config.require_ems;
+                tls12::CompleteClientHelloHandling {
+                    config: self.config,
+                    transcript,
+                    session_id: self.session_id,
+                    suite,
+                    using_ems: self.using_ems,
+                    force_using_ems,
+                    randoms,
+                    send_ticket: self.send_tickets > 0,
+                    extra_exts: self.extra_exts,
+                }
+                .handle_client_hello(
+                    cx,
+                    certkey,
+                    m,
+                    client_hello,
+                    sig_schemes,
+                    tls13_enabled,
+                )
             }
-            .handle_client_hello(
-                cx,
-                certkey,
-                m,
-                client_hello,
-                sig_schemes,
-                tls13_enabled,
-            ),
         }
     }
 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -315,6 +315,14 @@ pub struct ServerConfig {
     /// If this is 0, no tickets are sent and clients will not be able to
     /// do any resumption.
     pub send_tls13_tickets: usize,
+
+    /// If set to `true`, requires the client to support the extended
+    /// master secret extraction method defined in [RFC 7627].
+    /// The default is `false`.
+    ///
+    /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
+    #[cfg(feature = "tls12")]
+    pub require_ems: bool,
 }
 
 // Avoid a `Clone` bound on `C`.
@@ -335,6 +343,8 @@ impl Clone for ServerConfig {
             max_early_data_size: self.max_early_data_size,
             send_half_rtt_data: self.send_half_rtt_data,
             send_tls13_tickets: self.send_tls13_tickets,
+            #[cfg(feature = "tls12")]
+            require_ems: self.require_ems,
         }
     }
 }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -61,6 +61,7 @@ mod client_hello {
         pub(in crate::server) session_id: SessionId,
         pub(in crate::server) suite: &'static Tls12CipherSuite,
         pub(in crate::server) using_ems: bool,
+        pub(in crate::server) force_using_ems: bool,
         pub(in crate::server) randoms: ConnectionRandoms,
         pub(in crate::server) send_ticket: bool,
         pub(in crate::server) extra_exts: Vec<ServerExtension>,
@@ -81,6 +82,11 @@ mod client_hello {
 
             if client_hello.ems_support_offered() {
                 self.using_ems = true;
+            } else if self.force_using_ems {
+                return Err(cx.common.send_fatal_alert(
+                    AlertDescription::HandshakeFailure,
+                    PeerIncompatible::ExtendedMasterSecretExtensionRequired,
+                ));
             }
 
             let groups_ext = client_hello.get_namedgroups_extension();

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5350,6 +5350,64 @@ fn test_client_rejects_illegal_tls13_ccs() {
     );
 }
 
+#[cfg(feature = "tls12")]
+fn remove_ems_request(msg: &mut Message) -> Altered {
+    if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
+        if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
+            ch.extensions
+                .retain(|ext| !matches!(ext, ClientExtension::ExtendedMasterSecretRequest))
+        }
+
+        *encoded = Payload::new(parsed.get_encoding());
+    }
+
+    Altered::InPlace
+}
+
+#[cfg(feature = "tls12")]
+#[test]
+fn test_client_rejects_no_extended_master_secret_extension_when_force_using_ems() {
+    let key_type = KeyType::Rsa;
+    let mut client_config = make_client_config(key_type);
+    client_config.require_ems = true;
+    let server_config = finish_server_config(
+        key_type,
+        server_config_builder_with_versions(&[&rustls::version::TLS12]),
+    );
+    let (client, server) = make_pair_for_configs(client_config, server_config);
+    let (mut client, mut server) = (client.into(), server.into());
+    transfer_altered(&mut client, remove_ems_request, &mut server);
+    server.process_new_packets().unwrap();
+    transfer_altered(&mut server, |_| Altered::InPlace, &mut client);
+    assert_eq!(
+        client.process_new_packets(),
+        Err(Error::PeerIncompatible(
+            PeerIncompatible::ExtendedMasterSecretExtensionRequired
+        ))
+    );
+}
+
+#[cfg(feature = "tls12")]
+#[test]
+fn test_server_rejects_no_extended_master_secret_extension_when_force_using_ems() {
+    let key_type = KeyType::Rsa;
+    let client_config = make_client_config(key_type);
+    let mut server_config = finish_server_config(
+        key_type,
+        server_config_builder_with_versions(&[&rustls::version::TLS12]),
+    );
+    server_config.require_ems = true;
+    let (client, server) = make_pair_for_configs(client_config, server_config);
+    let (mut client, mut server) = (client.into(), server.into());
+    transfer_altered(&mut client, remove_ems_request, &mut server);
+    assert_eq!(
+        server.process_new_packets(),
+        Err(Error::PeerIncompatible(
+            PeerIncompatible::ExtendedMasterSecretExtensionRequired
+        ))
+    );
+}
+
 /// https://github.com/rustls/rustls/issues/797
 #[cfg(feature = "tls12")]
 #[test]


### PR DESCRIPTION
Add config for force using `extended_master_secret` extension in TLS 1.2 (#7)

* Add server config for forcing expecting `extended_master_secret` extension from client.

* Add client config for forcing usage of `extended_master_secret` extension with peer.

* Add tests cases for server and client when force using `extended_master_secret` extension.