### PR TITLE
Add option to relax SNI validation

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -630,7 +630,7 @@ pub mod server {
     pub use handy::ServerSessionMemoryCache;
     pub use handy::{AlwaysResolvesServerRawPublicKeys, NoServerSessionStorage};
     pub use server_conn::{
-        Accepted, ClientHello, ProducesTickets, ResolvesServerCert, ServerConfig,
+        Accepted, ClientHello, InvalidSniPolicy, ProducesTickets, ResolvesServerCert, ServerConfig,
         ServerConnectionData, StoresServerSessions, UnbufferedServerConnection,
     };
     #[cfg(feature = "std")]

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -242,7 +242,7 @@ impl ServerNamePayload {
                     "Illegal SNI hostname received {:?}",
                     String::from_utf8_lossy(&raw.0)
                 );
-                Err(InvalidMessage::InvalidServerName)
+                Ok(Self::Unknown(Payload::Owned(raw.0)))
             }
         }
     }
@@ -290,6 +290,12 @@ impl TlsListElement for ServerName {
 pub(crate) trait ConvertServerNameList {
     fn has_duplicate_names_for_type(&self) -> bool;
     fn single_hostname(&self) -> Option<DnsName<'_>>;
+    fn any_ip_addr(&self) -> Option<&[u8]>;
+    fn any_unknown(&self) -> Option<&[u8]>;
+    fn any_invalid(&self) -> Option<&[u8]> {
+        self.any_ip_addr()
+            .or_else(|| self.any_unknown())
+    }
 }
 
 impl ConvertServerNameList for [ServerName] {
@@ -310,6 +316,22 @@ impl ConvertServerNameList for [ServerName] {
         self.iter()
             .filter_map(only_dns_hostnames)
             .next()
+    }
+
+    fn any_ip_addr(&self) -> Option<&[u8]> {
+        self.iter()
+            .find_map(|name| match &name.payload {
+                ServerNamePayload::IpAddress(ip_addr) => Some(&*ip_addr.0),
+                _ => None,
+            })
+    }
+
+    fn any_unknown(&self) -> Option<&[u8]> {
+        self.iter()
+            .find_map(|name| match &name.payload {
+                ServerNamePayload::Unknown(payload) => Some(payload.bytes()),
+                _ => None,
+            })
     }
 }
 
@@ -986,23 +1008,7 @@ impl ClientHelloPayload {
     pub(crate) fn sni_extension(&self) -> Option<&[ServerName]> {
         let ext = self.find_extension(ExtensionType::ServerName)?;
         match *ext {
-            // Does this comply with RFC6066?
-            //
-            // [RFC6066][] specifies that literal IP addresses are illegal in
-            // `ServerName`s with a `name_type` of `host_name`.
-            //
-            // Some clients incorrectly send such extensions: we choose to
-            // successfully parse these (into `ServerNamePayload::IpAddress`)
-            // but then act like the client sent no `server_name` extension.
-            //
-            // [RFC6066]: https://datatracker.ietf.org/doc/html/rfc6066#section-3
-            ClientExtension::ServerName(ref req)
-                if !req
-                    .iter()
-                    .any(|name| matches!(name.payload, ServerNamePayload::IpAddress(_))) =>
-            {
-                Some(req)
-            }
+            ClientExtension::ServerName(ref req) => Some(req),
             _ => None,
         }
     }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -255,8 +255,9 @@ fn rejects_truncated_sni() {
     let bytes = [0, 0, 0, 4, 0, 2, 0, 0];
     assert!(ClientExtension::read(&mut Reader::init(&bytes)).is_err());
 
-    let bytes = [0, 0, 0, 5, 0, 3, 0, 0, 0];
-    assert!(ClientExtension::read(&mut Reader::init(&bytes)).is_err());
+    // This is empty SNI (and not truncated)
+    // let bytes = [0, 0, 0, 5, 0, 3, 0, 0, 0];
+    // assert!(ClientExtension::read(&mut Reader::init(&bytes)).is_err());
 
     let bytes = [0, 0, 0, 5, 0, 3, 0, 0, 1];
     assert!(ClientExtension::read(&mut Reader::init(&bytes)).is_err());

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 
 use pki_types::{CertificateDer, PrivateKeyDer};
 
+use super::server_conn::InvalidSniPolicy;
 use super::{handy, ResolvesServerCert, ServerConfig};
 use crate::builder::{ConfigBuilder, WantsVerifier};
 use crate::error::Error;
@@ -122,6 +123,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             cert_compressors: compress::default_cert_compressors().to_vec(),
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),
             cert_decompressors: compress::default_cert_decompressors().to_vec(),
+            invalid_sni_policy: InvalidSniPolicy::default(),
         }
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -29,7 +29,7 @@ use crate::msgs::persist;
 use crate::server::common::ActiveCertifiedKey;
 use crate::server::{tls13, ClientHello, ServerConfig};
 use crate::sync::Arc;
-use crate::{suites, SupportedCipherSuite};
+use crate::{suites, InvalidMessage, SupportedCipherSuite};
 
 pub(super) type NextState<'a> = Box<dyn State<ServerConnectionData> + 'a>;
 pub(super) type NextStateOrError<'a> = Result<NextState<'a>, Error>;
@@ -132,8 +132,12 @@ impl ExtensionProcessing {
         }
 
         let for_resume = resumedata.is_some();
-        // SNI
-        if !for_resume && hello.sni_extension().is_some() {
+        // SNI. Only acknowledge if it is valid
+        if !for_resume
+            && hello
+                .sni_extension()
+                .is_some_and(|sni| sni.any_invalid().is_none())
+        {
             self.exts
                 .push(ServerExtension::ServerNameAck);
         }
@@ -341,6 +345,17 @@ impl ExpectClientHello {
         let tls12_enabled = self
             .config
             .supports_version(ProtocolVersion::TLSv1_2);
+
+        if !self
+            .config
+            .invalid_sni_policy
+            .is_acceptable(client_hello)
+        {
+            return Err(cx.common.send_fatal_alert(
+                AlertDescription::IllegalParameter,
+                InvalidMessage::InvalidServerName,
+            ));
+        }
 
         // Are we doing TLS1.3?
         let maybe_versions_ext = client_hello.versions_extension();
@@ -695,10 +710,10 @@ pub(super) fn process_client_hello<'m>(
     cx.common.check_aligned_handshake()?;
 
     // Extract and validate the SNI DNS name, if any, before giving it to
-    // the cert resolver. In particular, if it is invalid then we should
-    // send an Illegal Parameter alert instead of the Internal Error alert
-    // (or whatever) that we'd send if this were checked later or in a
-    // different way.
+    // the cert resolver. If the DNS name is invalid (e.g., it's an IP address,
+    // or it contains invalid characters), we don't set it on the context, but
+    // we don't immediately return an error either, as dealing with invalid SNIs
+    // is subject to `InvalidSniPolicy` configured on the server.
     let sni: Option<DnsName<'_>> = match client_hello.sni_extension() {
         Some(sni) => {
             if sni.has_duplicate_names_for_type() {
@@ -708,14 +723,15 @@ pub(super) fn process_client_hello<'m>(
                 ));
             }
 
-            if let Some(hostname) = sni.single_hostname() {
-                Some(hostname.to_lowercase_owned())
-            } else {
+            if sni.is_empty() {
                 return Err(cx.common.send_fatal_alert(
                     AlertDescription::IllegalParameter,
                     PeerMisbehaved::ServerNameMustContainOneHostName,
                 ));
             }
+
+            sni.single_hostname()
+                .map(|hostname| hostname.to_lowercase_owned())
         }
         None => None,
     };

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -20,10 +20,12 @@ use crate::crypto;
 use crate::crypto::CryptoProvider;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
-use crate::log::trace;
+use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::enums::CertificateType;
-use crate::msgs::handshake::{ClientHelloPayload, ProtocolName, ServerExtension};
+use crate::msgs::handshake::{
+    ClientHelloPayload, ConvertServerNameList, ProtocolName, ServerExtension,
+};
 use crate::msgs::message::Message;
 use crate::sync::Arc;
 #[cfg(feature = "std")]
@@ -217,6 +219,53 @@ impl<'a> ClientHello<'a> {
     }
 }
 
+/// This Policy determines how invalid SNI should be handled by the rustls server.
+///
+/// The only valid form of SNI according to relevant RFCs ([RFC6066], [RFC1035]) is
+/// non-IP-address HostNames.
+///
+/// [RFC1035]: https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1
+/// [RFC6066]: https://datatracker.ietf.org/doc/html/rfc6066#section-3
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+#[non_exhaustive]
+pub enum InvalidSniPolicy {
+    /// Reject all ClientHello messages that contain invalid SNI
+    RejectAll,
+    /// Ignore SNI in ClientHello messages if they are IP addresses.
+    ///
+    /// "Ignoring SNI" means accepting the ClientHello message, but acting as if the client sent no SNI.
+    #[default]
+    IgnoreIpAddresses,
+    /// Ignore all invalid SNI in ClientHello messages.
+    ///
+    /// "Ignoring SNI" means accepting the ClientHello message, but acting as if the client sent no SNI.
+    IgnoreAll,
+}
+
+impl InvalidSniPolicy {
+    /// Check if any potential invalid SNI in ClientHello is acceptable (i.e., ignorable)
+    /// by this policy.
+    ///
+    /// A `false` return value means there is an invalid SNI in ClientHello that is
+    /// rejected by this policy.
+    pub(super) fn is_acceptable(&self, client_hello: &ClientHelloPayload) -> bool {
+        let maybe_bad_sni = client_hello
+            .sni_extension()
+            .and_then(|sni| match self {
+                Self::RejectAll => sni.any_invalid(),
+                Self::IgnoreIpAddresses => sni.any_unknown(),
+                Self::IgnoreAll => None,
+            });
+        if let Some(_bad_sni) = maybe_bad_sni {
+            debug!(
+                "Invalid SNI {:?} is rejected by InvalidSniPolicy {self:?}",
+                alloc::string::String::from_utf8_lossy(_bad_sni)
+            );
+        }
+        maybe_bad_sni.is_none()
+    }
+}
+
 /// Common configuration for a set of server sessions.
 ///
 /// Making one of these is cheap, though one of the inputs may be expensive: gathering trust roots
@@ -390,6 +439,9 @@ pub struct ServerConfig {
     ///
     /// [RFC8779]: https://datatracker.ietf.org/doc/rfc8879/
     pub cert_decompressors: Vec<&'static dyn compress::CertDecompressor>,
+
+    /// Determines how invalid SNI in ClientHello is handled.
+    pub invalid_sni_policy: InvalidSniPolicy,
 }
 
 impl ServerConfig {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -21,7 +21,7 @@ use rustls::internal::msgs::handshake::{
     ServerExtension, ServerName as ServerNameExtensionItem, SessionId,
 };
 use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
-use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
+use rustls::server::{ClientHello, InvalidSniPolicy, ParsedCertificate, ResolvesServerCert};
 #[cfg(feature = "aws_lc_rs")]
 use rustls::{
     client::{EchConfig, EchGreaseConfig, EchMode},
@@ -1490,6 +1490,82 @@ fn server_rejects_sni_with_illegal_dns_name() {
     );
 }
 
+#[test]
+fn server_invalid_sni_policy() {
+    const SERVER_NAME_GOOD: &str = "LXXXxxxXXXR";
+    const SERVER_NAME_BAAD: &str = "[XXXxxxXXX]";
+    const SERVER_NAME_IPV4: &str = "10.11.12.13";
+
+    fn replace_sni(sni_replacement: &str) -> impl Fn(&mut Message) -> Altered + '_ {
+        assert_eq!(sni_replacement.len(), SERVER_NAME_GOOD.len());
+        move |m: &mut Message| {
+            alter_sni_extension(
+                m,
+                |_| (),
+                |_parsed, encoded| {
+                    let mut payload_bytes = encoded.bytes().to_vec();
+                    if let Some(ind) = payload_bytes
+                        .windows(SERVER_NAME_GOOD.len())
+                        .position(|w| w == SERVER_NAME_GOOD.as_bytes())
+                    {
+                        payload_bytes[ind..][..SERVER_NAME_GOOD.len()]
+                            .copy_from_slice(sni_replacement.as_bytes());
+                    }
+
+                    Payload::new(payload_bytes)
+                },
+            )
+        }
+    }
+
+    enum ExpectedResult {
+        Accept,
+        AcceptNoSni,
+        Reject,
+    }
+    use ExpectedResult::*;
+    use InvalidSniPolicy as Policy;
+    let test_cases = [
+        (Policy::RejectAll, SERVER_NAME_GOOD, Accept),
+        (Policy::RejectAll, SERVER_NAME_IPV4, Reject),
+        (Policy::IgnoreAll, SERVER_NAME_GOOD, Accept),
+        (Policy::IgnoreAll, SERVER_NAME_IPV4, AcceptNoSni),
+        (Policy::IgnoreAll, SERVER_NAME_BAAD, AcceptNoSni),
+        (Policy::IgnoreIpAddresses, SERVER_NAME_GOOD, Accept),
+        (Policy::IgnoreIpAddresses, SERVER_NAME_IPV4, AcceptNoSni),
+        (Policy::IgnoreIpAddresses, SERVER_NAME_BAAD, Reject),
+    ];
+
+    let accept_result = Err(Error::General(
+        "no server certificate chain resolved".to_string(),
+    ));
+    let reject_result = Err(Error::InvalidMessage(InvalidMessage::InvalidServerName));
+
+    for (policy, sni, expected_result) in test_cases {
+        let client_config = make_client_config(KeyType::EcdsaP256);
+        let mut server_config = make_server_config(KeyType::EcdsaP256);
+
+        server_config.cert_resolver = Arc::new(ServerCheckSni {
+            expect_sni: matches!(expected_result, ExpectedResult::Accept),
+        });
+        server_config.invalid_sni_policy = policy;
+
+        let client =
+            ClientConnection::new(Arc::new(client_config), server_name(SERVER_NAME_GOOD)).unwrap();
+        let server = ServerConnection::new(Arc::new(server_config)).unwrap();
+        let (mut client, mut server) = (client.into(), server.into());
+
+        transfer_altered(&mut client, replace_sni(sni), &mut server);
+        assert_eq!(
+            &server.process_new_packets(),
+            match expected_result {
+                Accept | AcceptNoSni => &accept_result,
+                Reject => &reject_result,
+            }
+        );
+    }
+}
+
 fn alter_sni_extension(
     msg: &mut Message,
     alter_inner: impl Fn(&mut Vec<ServerNameExtensionItem>),
@@ -1514,7 +1590,7 @@ fn check_sni_error(alteration: impl Fn(&mut Message) -> Altered, expected_error:
         let client_config = make_client_config(*kt);
         let mut server_config = make_server_config(*kt);
 
-        server_config.cert_resolver = Arc::new(ServerCheckNoSni {});
+        server_config.cert_resolver = Arc::new(ServerCheckSni { expect_sni: false });
 
         let client =
             ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
@@ -1607,11 +1683,13 @@ fn server_cert_resolve_reduces_sigalgs_for_ecdsa_ciphersuite() {
 }
 
 #[derive(Debug)]
-struct ServerCheckNoSni {}
+struct ServerCheckSni {
+    expect_sni: bool,
+}
 
-impl ResolvesServerCert for ServerCheckNoSni {
+impl ResolvesServerCert for ServerCheckSni {
     fn resolve(&self, client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
-        assert!(client_hello.server_name().is_none());
+        assert_eq!(client_hello.server_name().is_some(), self.expect_sni);
 
         None
     }
@@ -1621,7 +1699,7 @@ impl ResolvesServerCert for ServerCheckNoSni {
 fn client_with_sni_disabled_does_not_send_sni() {
     for kt in ALL_KEY_TYPES {
         let mut server_config = make_server_config(*kt);
-        server_config.cert_resolver = Arc::new(ServerCheckNoSni {});
+        server_config.cert_resolver = Arc::new(ServerCheckSni { expect_sni: false });
         let server_config = Arc::new(server_config);
 
         for version in rustls::ALL_VERSIONS {


### PR DESCRIPTION
See the upstream issue https://github.com/rustls/rustls/issues/2403 for more context. 

This PR adds this option to our fork, so we can use it temporarily until we can open and merge a PR against upstream.